### PR TITLE
refact:  Move logic for running multiple speedup to a separate module

### DIFF
--- a/simulation/src/lib.rs
+++ b/simulation/src/lib.rs
@@ -9,6 +9,7 @@ mod maxclique;
 mod problem;
 mod simpleapi;
 mod extremalsets;
+mod search;
 
 pub use crate::auto::AutomaticSimplifications;
 pub use crate::autolb::AutoLb;
@@ -22,3 +23,4 @@ pub use crate::bignum::BigNum1;
 pub use crate::problem::Config;
 pub use crate::problem::Normalized;
 pub use crate::bignum::BigNum;
+pub use crate::search::do_multiple_speedups;

--- a/simulation/src/search.rs
+++ b/simulation/src/search.rs
@@ -1,0 +1,49 @@
+use crate::problem::Normalized;
+use crate::problem::GenericProblem;
+use crate::problem::ResultProblem;
+
+fn has_periodic_point(
+  curr_normalized_problem: &Normalized,
+  prev_normalized_problems: &Vec<Normalized>
+) -> bool {
+  for prev_problem in prev_normalized_problems {
+      if curr_normalized_problem == prev_problem {
+          return true;
+      }
+  }
+  return false;
+}
+
+pub fn do_multiple_speedups(
+  mut p: GenericProblem,
+  iter: usize,
+  merge : bool,
+  find_periodic_point: bool
+) -> (Vec<ResultProblem>, bool) {
+  // Save normalized representations of problems derived on each iteration.
+  // Used to search for periodic points later on.
+  let mut derived_normalized_problems = Vec::new();
+  let mut results = Vec::new();
+  let mut found_periodic_point = false;
+
+  if find_periodic_point {
+      derived_normalized_problems.push(p.normalize());  
+  }
+
+  for _ in 0..iter {
+      p = p.speedup().unwrap();
+    
+      if merge && !p.mergeable.as_ref().unwrap().is_empty() {
+          p = p.merge_equal();  
+      }
+      results.push(p.as_result());
+
+      let normalized_p = p.normalize();
+      found_periodic_point = found_periodic_point ||
+                            has_periodic_point(&normalized_p, &derived_normalized_problems);
+
+      derived_normalized_problems.push(normalized_p);
+    }
+
+    return (results, found_periodic_point);
+}


### PR DESCRIPTION
Moved logic for running multiple speedups to a separate module. The idea is that the same function later could be used from cli.rs and e.g. simpleapi.rs

search.rs is a rather silly name. But the idea is that I'll later put there a  function that will do autolb, autoub, search for periodic point, etc. If you have ideas for better naming, please propose